### PR TITLE
fix return value of romfs_stat for non-existent files/directories

### DIFF
--- a/libctru/source/romfs_dev.c
+++ b/libctru/source/romfs_dev.c
@@ -737,7 +737,7 @@ int romfs_stat(struct _reent *r, const char *path, struct stat *st)
 	}
 
 	r->_errno = ENOENT;
-	return 1;
+	return -1;
 }
 
 int romfs_chdir(struct _reent *r, const char *path)


### PR DESCRIPTION
stat is defined to return 0 or -1, this is probably a typo of -1?