### PR TITLE
Fix FSPXI_CreateFile and FSPXI_WriteFile

### DIFF
--- a/libctru/source/services/fspxi.c
+++ b/libctru/source/services/fspxi.c
@@ -229,8 +229,8 @@ Result FSPXI_WriteFile(Handle serviceHandle, FSPXI_File file, u32* bytesWritten,
 	cmdbuf[2] = (u32)(file >> 32);
 	cmdbuf[3] = (u32) offset;
 	cmdbuf[4] = (u32) (offset >> 32);
-	cmdbuf[5] = flags;
-	cmdbuf[6] = size;
+	cmdbuf[5] = size;
+	cmdbuf[6] = flags;
 	cmdbuf[7] = IPC_Desc_PXIBuffer(size, 0, true);
 	cmdbuf[8] = (u32) buffer;
 

--- a/libctru/source/services/fspxi.c
+++ b/libctru/source/services/fspxi.c
@@ -107,8 +107,8 @@ Result FSPXI_CreateFile(Handle serviceHandle, FSPXI_Archive archive, FS_Path pat
 	cmdbuf[6] = attributes;
 	cmdbuf[7] = (u32)fileSize;
 	cmdbuf[8] = (u32)(fileSize >> 32);
-	cmdbuf[8] = IPC_Desc_PXIBuffer(path.size, 0, true);
-	cmdbuf[9] = (u32) path.data;
+	cmdbuf[9] = IPC_Desc_PXIBuffer(path.size, 0, true);
+	cmdbuf[10] = (u32) path.data;
 
 	if(R_FAILED(ret = svcSendSyncRequest(serviceHandle))) return ret;
 


### PR DESCRIPTION
**FSPXI_CreateFile**: the command buffer at index 8 was assigned twice. See here: https://3dbrew.org/wiki/FSPXI:CreateFile
Creating any file with valid arguments results in 0xD9001830.

Regarding **FSPXI_WriteFile**: the `size` and `flags` are actually swapped. I found this out after some code analysis of the fs codebin.
This is what it looks like:
![image](https://user-images.githubusercontent.com/18742654/172057210-5225f299-5324-4a0f-9793-71c4134be7fb.png)
Looking a bit closer, the size and flags are swapped. The same size being used for the buffer descriptor confirms this as well.