### PR TITLE
Minor style consistency fix for svcExitProcess

### DIFF
--- a/libctru/include/3ds/svc.h
+++ b/libctru/include/3ds/svc.h
@@ -699,7 +699,7 @@ Result svcQueryProcessMemory(MemInfo* info, PageInfo* out, Handle process, u32 a
 Result svcOpenProcess(Handle* process, u32 processId);
 
 /// Exits the current process.
-void __attribute__((noreturn)) svcExitProcess();
+void svcExitProcess() __attribute__((noreturn));
 
 /**
  * @brief Terminates a process.


### PR DESCRIPTION
All the other functions in libctru have `__attribute__((noreturn))` after the declaration