### PR TITLE
Include for size_t

### DIFF
--- a/libctru/include/3ds/allocator/linear.h
+++ b/libctru/include/3ds/allocator/linear.h
@@ -4,6 +4,8 @@
  */
 #pragma once
 
+#include <stddef.h>
+
 /**
  * @brief Allocates a 0x80-byte aligned buffer.
  * @param size Size of the buffer to allocate.


### PR DESCRIPTION
For standalone usage.