### PR TITLE
add various ndspGet* methods

### DIFF
--- a/libctru/include/3ds/ndsp/ndsp.h
+++ b/libctru/include/3ds/ndsp/ndsp.h
@@ -119,10 +119,22 @@ u32    ndspGetFrameCount(void);
 void ndspSetMasterVol(float volume);
 
 /**
+ * @brief Gets the master volume.
+ * @return The master volume.
+ */
+void ndspGetMasterVol(void); 
+
+/**
  * @brief Sets the output mode.
  * @param mode Output mode to set. Defaults to NDSP_OUTPUT_STEREO.
  */
 void ndspSetOutputMode(ndspOutputMode mode);
+
+/**
+ * @brief Gets the output mode.
+ * @return The output mode.
+ */
+ndspOutputMode ndspGetOutputMode(void);
 
 /**
  * @brief Sets the clipping mode.
@@ -131,10 +143,22 @@ void ndspSetOutputMode(ndspOutputMode mode);
 void ndspSetClippingMode(ndspClippingMode mode);
 
 /**
+ * @brief Gets the clipping mode.
+ * @return The clipping mode.
+ */
+ndspClippingMode ndspGetClippingMode(void);
+
+/**
  * @brief Sets the output count.
  * @param count Output count to set. Defaults to 2.
  */
 void ndspSetOutputCount(int count);
+
+/**
+ * @brief Gets the output count.
+ * @return The output count.
+ */
+int ndspGetOutputCount(void);
 
 /**
  * @brief Sets the wave buffer to capture audio to.
@@ -159,16 +183,34 @@ void ndspSetCallback(ndspCallback callback, void* data);
 void ndspSurroundSetDepth(u16 depth);
 
 /**
+ * @brief Gets the surround sound depth.
+ * @return The surround sound depth.
+ */
+u16 ndspSurroundGetDepth(void);
+
+/**
  * @brief Sets the surround sound position.
  * @param pos Position to set. Defaults to NDSP_SPKPOS_SQUARE.
  */
 void ndspSurroundSetPos(ndspSpeakerPos pos);
 
 /**
+ * @brief Gets the surround sound position.
+ * @return The surround sound speaker position.
+ */
+ndspSpeakerPos ndspSurroundGetPos(void);
+
+/**
  * @brief Sets the surround sound rear ratio.
  * @param ratio Rear ratio to set. Defaults to 0x8000.
  */
 void ndspSurroundSetRearRatio(u16 ratio);
+
+/**
+ * @brief Gets the surround sound rear ratio.
+ * @return The rear ratio.
+ */
+u16 ndspSurroundGetRearRatio(void);
 ///@}
 
 ///@name Auxiliary output
@@ -181,6 +223,13 @@ void ndspSurroundSetRearRatio(u16 ratio);
 void ndspAuxSetEnable(int id, bool enable);
 
 /**
+ * @brief Gets whether auxiliary output is enabled.
+ * @param id ID of the auxiliary output.
+ * @return Whether auxiliary output is enabled.
+ */
+bool ndspAuxIsEnabled(int id);
+
+/**
  * @brief Configures whether an auxiliary output should use front bypass.
  * @param id ID of the auxiliary output.
  * @param bypass Whether to use front bypass.
@@ -188,11 +237,25 @@ void ndspAuxSetEnable(int id, bool enable);
 void ndspAuxSetFrontBypass(int id, bool bypass);
 
 /**
+ * @brief Gets whether auxiliary output front bypass is enabled.
+ * @param id ID of the auxiliary output.
+ * @return Whether auxiliary output front bypass is enabled.
+ */
+bool ndspAuxGetFrontBypass(int id);
+
+/**
  * @brief Sets the volume of an auxiliary output.
  * @param id ID of the auxiliary output.
  * @param volume Volume to set.
  */
 void ndspAuxSetVolume(int id, float volume);
+
+/**
+ * @brief Gets the volume of an auxiliary output.
+ * @param id ID of the auxiliary output.
+ * @return Volume of the auxiliary output.
+ */
+float ndspAuxGetVolume(int id);
 
 /**
  * @brief Sets the callback of an auxiliary output.

--- a/libctru/include/3ds/ndsp/ndsp.h
+++ b/libctru/include/3ds/ndsp/ndsp.h
@@ -122,7 +122,7 @@ void ndspSetMasterVol(float volume);
  * @brief Gets the master volume.
  * @return The master volume.
  */
-void ndspGetMasterVol(void); 
+float ndspGetMasterVol(void); 
 
 /**
  * @brief Sets the output mode.

--- a/libctru/source/ndsp/ndsp.c
+++ b/libctru/source/ndsp/ndsp.c
@@ -612,12 +612,22 @@ void ndspSetMasterVol(float volume)
 	LightLock_Unlock(&ndspMaster.lock);
 }
 
+void ndspGetMasterVol(void)
+{
+	return ndspMaster.masterVol;
+}
+
 void ndspSetOutputMode(ndspOutputMode mode)
 {
 	LightLock_Lock(&ndspMaster.lock);
 	ndspMaster.outputMode = mode;
 	ndspMaster.flags |= MFLAG_OUTPUTMODE;
 	LightLock_Unlock(&ndspMaster.lock);
+}
+
+ndspOutputMode ndspGetOutputMode(void)
+{
+	return ndspMaster.outputMode;
 }
 
 void ndspSetClippingMode(ndspClippingMode mode)
@@ -628,12 +638,22 @@ void ndspSetClippingMode(ndspClippingMode mode)
 	LightLock_Unlock(&ndspMaster.lock);
 }
 
+ndspClippingMode ndspGetClippingMode(void)
+{
+	return ndspMaster.clippingMode;
+}
+
 void ndspSetOutputCount(int count)
 {
 	LightLock_Lock(&ndspMaster.lock);
 	ndspMaster.outputCount = count;
 	ndspMaster.flags |= MFLAG_OUTPUTCOUNT;
 	LightLock_Unlock(&ndspMaster.lock);
+}
+
+int ndspGetOutputCount(void)
+{
+	return ndspMaster.outputCount;
 }
 
 void ndspSetCapture(ndspWaveBuf* capture)
@@ -655,12 +675,22 @@ void ndspSurroundSetDepth(u16 depth)
 	LightLock_Unlock(&ndspMaster.lock);
 }
 
+u16 ndspSurroundGetDepth(void)
+{
+	return ndspMaster.surround.depth;
+}
+
 void ndspSurroundSetPos(ndspSpeakerPos pos)
 {
 	LightLock_Lock(&ndspMaster.lock);
 	ndspMaster.surround.pos = pos;
 	ndspMaster.flags |= MFLAG_SURR_POS;
 	LightLock_Unlock(&ndspMaster.lock);
+}
+
+ndspSpeakerPos ndspSurroundGetPos(void)
+{
+	return ndspMaster.surround.pos;
 }
 
 void ndspSurroundSetRearRatio(u16 ratio)
@@ -671,12 +701,22 @@ void ndspSurroundSetRearRatio(u16 ratio)
 	LightLock_Unlock(&ndspMaster.lock);
 }
 
+u16 ndspSurroundGetRearRatio(void)
+{
+	return ndspMaster.surround.rearRatio;
+}
+
 void ndspAuxSetEnable(int id, bool enable)
 {
 	LightLock_Lock(&ndspMaster.lock);
 	ndspMaster.aux[id].enable = enable ? 1 : 0;
 	ndspMaster.flags |= MFLAG_AUX_ENABLE(id);
 	LightLock_Unlock(&ndspMaster.lock);
+}
+
+bool ndspAuxIsEnabled(int id)
+{
+	return ndspMaster.aux[id].enable;
 }
 
 void ndspAuxSetFrontBypass(int id, bool bypass)
@@ -687,12 +727,22 @@ void ndspAuxSetFrontBypass(int id, bool bypass)
 	LightLock_Unlock(&ndspMaster.lock);
 }
 
+bool ndspGetFrontBypass(int id)
+{
+	return ndspMaster.aux[id].frontBypass;
+}
+
 void ndspAuxSetVolume(int id, float volume)
 {
 	LightLock_Lock(&ndspMaster.lock);
 	ndspMaster.aux[id].volume = volume;
 	ndspMaster.flags |= MFLAG_AUX_VOLUME(id);
 	LightLock_Unlock(&ndspMaster.lock);
+}
+
+float ndspAuxGetVolume(int id)
+{
+	return ndspMaster.aux[id].volume;
 }
 
 void ndspAuxSetCallback(int id, ndspAuxCallback callback, void* data)


### PR DESCRIPTION
This pull request add various `ndspGet*` methods for convenience *and* because they are tracked internally by libctru, applications cannot get this data otherwise. Most notably missing was `ndspGetMasterVol`, but I decided to add the remaining ones for consistency.