### PR TITLE
add various ndspChnGet* methods

### DIFF
--- a/libctru/include/3ds/ndsp/channel.h
+++ b/libctru/include/3ds/ndsp/channel.h
@@ -135,6 +135,13 @@ void ndspChnSetRate(int id, float rate);
 void ndspChnSetMix(int id, float mix[12]);
 
 /**
+ * @brief Gets the mix parameters (volumes) of a channel.
+ * @param id ID of the channel (0..23)
+ * @return The mix parameters.
+ */
+float* ndspChnGetMix(int id);
+
+/**
  * @brief Sets the DSPADPCM coefficients of a channel.
  * @param id ID of the channel (0..23).
  * @param coefs DSPADPCM coefficients to use.

--- a/libctru/include/3ds/ndsp/channel.h
+++ b/libctru/include/3ds/ndsp/channel.h
@@ -159,9 +159,9 @@ void ndspChnSetMix(int id, float mix[12]);
 /**
  * @brief Gets the mix parameters (volumes) of a channel.
  * @param id ID of the channel (0..23)
- * @return The mix parameters. See \ref ndspChnSetMix.
+ * @param mix Mix parameters to write out to. See \ref ndspChnSetMix.
  */
-float* ndspChnGetMix(int id);
+void ndspChnGetMix(int id, float* mix[12]);
 
 /**
  * @brief Sets the DSPADPCM coefficients of a channel.

--- a/libctru/include/3ds/ndsp/channel.h
+++ b/libctru/include/3ds/ndsp/channel.h
@@ -108,6 +108,14 @@ void ndspChnSetPaused(int id, bool paused);
 void ndspChnSetFormat(int id, u16 format);
 
 /**
+ * 
+ * @brief Gets the format of a channel.
+ * @param id ID of the channel (0..23).
+ * @return The format of the channel.
+ */
+u16 ndspChnGetFormat(int id);
+
+/**
  * @brief Sets the interpolation type of a channel.
  * @param id ID of the channel (0..23).
  * @param type Interpolation type to use.
@@ -115,11 +123,25 @@ void ndspChnSetFormat(int id, u16 format);
 void ndspChnSetInterp(int id, ndspInterpType type);
 
 /**
+ * @brief Gets the interpolation type of a channel.
+ * @param id ID of the channel (0..23).
+ * @return The interpolation type of the channel.
+ */
+ndspInterpType ndspChnGetInterp(int id);
+
+/**
  * @brief Sets the sample rate of a channel.
  * @param id ID of the channel (0..23).
  * @param rate Sample rate to use.
  */
 void ndspChnSetRate(int id, float rate);
+
+/**
+ * @brief Gets the sample rate of a channel.
+ * @param id ID of the channel (0..23).
+ * @return The sample rate of the channel.
+ */
+float ndspChnGetRate(int id);
 
 /**
  * @brief Sets the mix parameters (volumes) of a channel.
@@ -137,7 +159,7 @@ void ndspChnSetMix(int id, float mix[12]);
 /**
  * @brief Gets the mix parameters (volumes) of a channel.
  * @param id ID of the channel (0..23)
- * @return The mix parameters.
+ * @return The mix parameters. See \ref ndspChnSetMix.
  */
 float* ndspChnGetMix(int id);
 

--- a/libctru/source/ndsp/ndsp-channel.c
+++ b/libctru/source/ndsp/ndsp-channel.c
@@ -123,6 +123,12 @@ void ndspChnSetInterp(int id, ndspInterpType type)
 	LightLock_Unlock(&chn->lock);
 }
 
+ndspInterpType ndspChnGetInterp(int id)
+{
+    ndspChnSt* chn = &ndspChn[id];
+    return chn->interpType;
+}
+
 void ndspChnSetRate(int id, float rate)
 {
 	ndspChnSt* chn = &ndspChn[id];
@@ -132,6 +138,12 @@ void ndspChnSetRate(int id, float rate)
 	LightLock_Unlock(&chn->lock);
 }
 
+float ndspChnGetRate(int id)
+{
+    ndspChnSt* chn = &ndspChn[id];
+	return chn->rate;
+}
+
 void ndspChnSetMix(int id, float mix[12])
 {
 	ndspChnSt* chn = &ndspChn[id];
@@ -139,6 +151,12 @@ void ndspChnSetMix(int id, float mix[12])
 	memcpy(&chn->mix, mix, sizeof(ndspChn[id].mix));
 	chn->flags |= CFLAG_MIX;
 	LightLock_Unlock(&chn->lock);
+}
+
+float* ndspChnGetMix(int id)
+{
+    ndspChnSt* chn = &ndspChn[id];
+    return chn->mix;
 }
 
 void ndspChnSetAdpcmCoefs(int id, u16 coefs[16])

--- a/libctru/source/ndsp/ndsp-channel.c
+++ b/libctru/source/ndsp/ndsp-channel.c
@@ -153,10 +153,12 @@ void ndspChnSetMix(int id, float mix[12])
 	LightLock_Unlock(&chn->lock);
 }
 
-void ndspChnGetMix(int id, float mix[12])
+void ndspChnGetMix(int id, float out_mix[12])
 {
     ndspChnSt* chn = &ndspChn[id];
-    memcpy(mix, chn->mix, sizeof(mix));
+    LightLock_Lock(&chn->lock);
+    memcpy(out_mix, chn->mix, sizeof(ndspChn[id].mix));
+    LightLock_Unlock(&chn->lock);
 }
 
 void ndspChnSetAdpcmCoefs(int id, u16 coefs[16])

--- a/libctru/source/ndsp/ndsp-channel.c
+++ b/libctru/source/ndsp/ndsp-channel.c
@@ -153,10 +153,10 @@ void ndspChnSetMix(int id, float mix[12])
 	LightLock_Unlock(&chn->lock);
 }
 
-float* ndspChnGetMix(int id)
+void ndspChnGetMix(int id, float mix[12])
 {
     ndspChnSt* chn = &ndspChn[id];
-    return chn->mix;
+    memcpy(mix, chn->mix, sizeof(mix));
 }
 
 void ndspChnSetAdpcmCoefs(int id, u16 coefs[16])


### PR DESCRIPTION
This pull request adds a few methods to get `ndspChn` data. This is for the same reasons as #505.