### PR TITLE
Enable offline documentation by providing docsets

### DIFF
--- a/.github/workflows/doxygen.yaml
+++ b/.github/workflows/doxygen.yaml
@@ -29,6 +29,11 @@ jobs:
                git clone --branch=master --single-branch --depth 1 https://github.com/devkitPro/3ds-examples examples
                cd libctru
                CTRU_VERSION=${{ steps.vars.outputs.tag }} doxygen Doxyfile
+      - name: Publish docs to GH Actions
+        uses: actions/upload-artifact@v2
+        with:
+          path: libctru/docs/*
+          name: docs
 
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@3.7.1
@@ -38,3 +43,28 @@ jobs:
           FOLDER: libctru/docs/html
           CLEAN: true
           SINGLE_COMMIT: true
+
+  generatedocset:
+      name: Generate Docset
+      runs-on: macos-latest
+      needs: build
+      steps:
+        - name: Pick up artifacts
+          uses: actions/download-artifact@master
+          with:
+            name: docs
+            path: docs
+        - name: Set up docsetutil
+          run: |
+                git clone https://github.com/SwiftDocOrg/DocSetUtil.git
+                cd DocSetUtil
+                make install
+        - name: Build Docset
+          run: |
+                cd docs/html/
+                make XCODE_INSTALL=../../DocSetUtil/Developer
+        - name: Publish docs to GH Actions
+          uses: actions/upload-artifact@v2
+          with:
+            path: docs/html/org.devkitPro.libctru.docset/
+            name: org.devkitpro.libctru.docset

--- a/libctru/Doxyfile
+++ b/libctru/Doxyfile
@@ -1200,7 +1200,7 @@ HTML_INDEX_NUM_ENTRIES = 100
 # The default value is: NO.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-GENERATE_DOCSET        = NO
+GENERATE_DOCSET        = YES
 
 # This tag determines the name of the docset feed. A documentation feed provides
 # an umbrella under which multiple documentation sets from a single provider
@@ -1208,7 +1208,7 @@ GENERATE_DOCSET        = NO
 # The default value is: Doxygen generated docs.
 # This tag requires that the tag GENERATE_DOCSET is set to YES.
 
-DOCSET_FEEDNAME        = "Doxygen generated docs"
+DOCSET_FEEDNAME        = "Doxygen libctru docs"
 
 # This tag specifies a string that should uniquely identify the documentation
 # set bundle. This should be a reverse domain-name style string, e.g.
@@ -1216,7 +1216,7 @@ DOCSET_FEEDNAME        = "Doxygen generated docs"
 # The default value is: org.doxygen.Project.
 # This tag requires that the tag GENERATE_DOCSET is set to YES.
 
-DOCSET_BUNDLE_ID       = org.doxygen.Project
+DOCSET_BUNDLE_ID       = org.devkitPro.libctru
 
 # The DOCSET_PUBLISHER_ID tag specifies a string that should uniquely identify
 # the documentation publisher. This should be a reverse domain-name style
@@ -1224,13 +1224,13 @@ DOCSET_BUNDLE_ID       = org.doxygen.Project
 # The default value is: org.doxygen.Publisher.
 # This tag requires that the tag GENERATE_DOCSET is set to YES.
 
-DOCSET_PUBLISHER_ID    = org.doxygen.Publisher
+DOCSET_PUBLISHER_ID    = org.devkitPro.libctru
 
 # The DOCSET_PUBLISHER_NAME tag identifies the documentation publisher.
 # The default value is: Publisher.
 # This tag requires that the tag GENERATE_DOCSET is set to YES.
 
-DOCSET_PUBLISHER_NAME  = Publisher
+DOCSET_PUBLISHER_NAME  = devkitPro
 
 # If the GENERATE_HTMLHELP tag is set to YES then doxygen generates three
 # additional HTML index files: index.hhp, index.hhc, and index.hhk. The


### PR DESCRIPTION
Hello, I've gotten very frustrated at doxygen's search feature not showing me the suitable functions for my objectives right away (be it because the name of the function doesn't start *exactly* by the search string or by being slow at doing it's job, it's laggy).  
So I've found an article in hackernews promoting the wonders of offline documentation and showed docsets as a simple but effective option at doing so(while they were created for apple computers, with the right apps, like zeal which is free and cross platform, one can make full use of them in any computer). I did some research and came up with the knowledge needed to make doxygen generate the raw docsets and a way to index them and make them proper usable
This PR request sets the workflow to provide the docsets in artifacts, but they could probably be moved somehow to releases.