### PR TITLE
Fix: ndsp-channel.c indentation

### DIFF
--- a/libctru/source/ndsp/ndsp-channel.c
+++ b/libctru/source/ndsp/ndsp-channel.c
@@ -125,8 +125,8 @@ void ndspChnSetInterp(int id, ndspInterpType type)
 
 ndspInterpType ndspChnGetInterp(int id)
 {
-    ndspChnSt* chn = &ndspChn[id];
-    return chn->interpType;
+	ndspChnSt* chn = &ndspChn[id];
+	return chn->interpType;
 }
 
 void ndspChnSetRate(int id, float rate)
@@ -140,7 +140,7 @@ void ndspChnSetRate(int id, float rate)
 
 float ndspChnGetRate(int id)
 {
-    ndspChnSt* chn = &ndspChn[id];
+	ndspChnSt* chn = &ndspChn[id];
 	return chn->rate;
 }
 
@@ -155,10 +155,10 @@ void ndspChnSetMix(int id, float mix[12])
 
 void ndspChnGetMix(int id, float out_mix[12])
 {
-    ndspChnSt* chn = &ndspChn[id];
-    LightLock_Lock(&chn->lock);
-    memcpy(out_mix, chn->mix, sizeof(ndspChn[id].mix));
-    LightLock_Unlock(&chn->lock);
+	ndspChnSt* chn = &ndspChn[id];
+	LightLock_Lock(&chn->lock);
+	memcpy(out_mix, chn->mix, sizeof(ndspChn[id].mix));
+	LightLock_Unlock(&chn->lock);
 }
 
 void ndspChnSetAdpcmCoefs(int id, u16 coefs[16])


### PR DESCRIPTION
I somehow managed to mess up the indentation from the prior pr's for ndspGet*/ndspChnGet*. This fixes that, converting spaces to tabs in vscode, and apologies for not noticing it sooner. If there's any other indentation bits that look wrong in ndsp-channel.c or ndsp.c, please let me know and I'll fix them as well. I'll also take a look as well.