### PR TITLE
archive_dev: Ensure path seperator for local path

### DIFF
--- a/libctru/source/archive_dev.c
+++ b/libctru/source/archive_dev.c
@@ -205,9 +205,11 @@ archive_fixpath(struct _reent    *r,
     strncpy(__ctru_dev_path_buf, path, PATH_MAX);
   else
   {
+    size_t cwdlen = strlen(dev->cwd);
     strncpy(__ctru_dev_path_buf, dev->cwd, PATH_MAX);
     __ctru_dev_path_buf[PATH_MAX] = '\0';
-    strncat(__ctru_dev_path_buf, path, PATH_MAX);
+    strncat(__ctru_dev_path_buf, "/", PATH_MAX - cwdlen);
+    strncat(__ctru_dev_path_buf, path, PATH_MAX - cwdlen - 1);
   }
 
   if(__ctru_dev_path_buf[PATH_MAX] != 0)


### PR DESCRIPTION
Fixes issue where fopen("test.txt","r") opens 3dstest.txt instead of test.txt.

Also correct misuse of strncat() as count applies to src not dest.

See:
https://github.com/devkitPro/3ds-hbmenu/commit/8136d94657dff0075103f0cf36ed5f2d9159e27c https://github.com/devkitPro/newlib/commit/806a4d34c5408d393dbd2b6b9cae22184c57d3a8