### PR TITLE
Add CTR_ prefix to ALIGN,PACKED,DEPRECATED macros

### DIFF
--- a/libctru/Doxyfile
+++ b/libctru/Doxyfile
@@ -2023,7 +2023,7 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             = LIBCTRU_PACKED
+PREDEFINED             = CTR_PACKED
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/libctru/Doxyfile
+++ b/libctru/Doxyfile
@@ -2023,7 +2023,7 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             = PACKED
+PREDEFINED             = LIBCTRU_PACKED
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/libctru/include/3ds/gfx.h
+++ b/libctru/include/3ds/gfx.h
@@ -166,7 +166,7 @@ void gfxScreenSwapBuffers(gfxScreen_t scr, bool hasStereo);
  * @param immediate This parameter no longer has any effect and is thus ignored.
  * @deprecated This function has been superseded by \ref gfxScreenSwapBuffers, please use that instead.
  */
-DEPRECATED void gfxConfigScreen(gfxScreen_t scr, bool immediate);
+LIBCTRU_DEPRECATED void gfxConfigScreen(gfxScreen_t scr, bool immediate);
 
 /**
  * @brief Updates the configuration of both screens.

--- a/libctru/include/3ds/gfx.h
+++ b/libctru/include/3ds/gfx.h
@@ -166,7 +166,7 @@ void gfxScreenSwapBuffers(gfxScreen_t scr, bool hasStereo);
  * @param immediate This parameter no longer has any effect and is thus ignored.
  * @deprecated This function has been superseded by \ref gfxScreenSwapBuffers, please use that instead.
  */
-LIBCTRU_DEPRECATED void gfxConfigScreen(gfxScreen_t scr, bool immediate);
+CTR_DEPRECATED void gfxConfigScreen(gfxScreen_t scr, bool immediate);
 
 /**
  * @brief Updates the configuration of both screens.

--- a/libctru/include/3ds/ipc.h
+++ b/libctru/include/3ds/ipc.h
@@ -70,7 +70,7 @@ static inline u32 IPC_Desc_CurProcessId(void)
 	return 0x20;
 }
 
-static inline DEPRECATED u32 IPC_Desc_CurProcessHandle(void)
+static inline LIBCTRU_DEPRECATED u32 IPC_Desc_CurProcessHandle(void)
 {
 	return IPC_Desc_CurProcessId();
 }

--- a/libctru/include/3ds/ipc.h
+++ b/libctru/include/3ds/ipc.h
@@ -70,7 +70,7 @@ static inline u32 IPC_Desc_CurProcessId(void)
 	return 0x20;
 }
 
-static inline LIBCTRU_DEPRECATED u32 IPC_Desc_CurProcessHandle(void)
+static inline CTR_DEPRECATED u32 IPC_Desc_CurProcessHandle(void)
 {
 	return IPC_Desc_CurProcessId();
 }

--- a/libctru/include/3ds/mii.h
+++ b/libctru/include/3ds/mii.h
@@ -147,7 +147,7 @@ typedef struct
 	} glasses_details;
 
 	/// Mole details
-	struct 
+	struct
 	{
 		bool enable : 1;
 		u16 scale : 5;
@@ -156,4 +156,4 @@ typedef struct
 	} mole_details;
 
 	u16 author_name[10];    ///< Name of Mii's author (Encoded using UTF16)
-} LIBCTRU_PACKED MiiData;
+} CTR_PACKED MiiData;

--- a/libctru/include/3ds/mii.h
+++ b/libctru/include/3ds/mii.h
@@ -156,4 +156,4 @@ typedef struct
 	} mole_details;
 
 	u16 author_name[10];    ///< Name of Mii's author (Encoded using UTF16)
-} PACKED MiiData;
+} LIBCTRU_PACKED MiiData;

--- a/libctru/include/3ds/services/apt.h
+++ b/libctru/include/3ds/services/apt.h
@@ -176,7 +176,7 @@ bool aptShouldJumpToHome(void);
 bool aptCheckHomePressRejected(void);
 
 /// \deprecated Alias for \ref aptCheckHomePressRejected.
-static inline LIBCTRU_DEPRECATED bool aptIsHomePressed(void)
+static inline CTR_DEPRECATED bool aptIsHomePressed(void)
 {
 	return aptCheckHomePressRejected();
 }

--- a/libctru/include/3ds/services/apt.h
+++ b/libctru/include/3ds/services/apt.h
@@ -176,7 +176,7 @@ bool aptShouldJumpToHome(void);
 bool aptCheckHomePressRejected(void);
 
 /// \deprecated Alias for \ref aptCheckHomePressRejected.
-static inline DEPRECATED bool aptIsHomePressed(void)
+static inline LIBCTRU_DEPRECATED bool aptIsHomePressed(void)
 {
 	return aptCheckHomePressRejected();
 }

--- a/libctru/include/3ds/services/fs.h
+++ b/libctru/include/3ds/services/fs.h
@@ -202,7 +202,7 @@ typedef struct
 } FS_IntegrityVerificationSeed;
 
 /// Ext save data information.
-typedef struct PACKED
+typedef struct LIBCTRU_PACKED
 {
 	FS_MediaType mediaType : 8; ///< Media type.
 	u8 unknown;                 ///< Unknown.

--- a/libctru/include/3ds/services/fs.h
+++ b/libctru/include/3ds/services/fs.h
@@ -202,7 +202,7 @@ typedef struct
 } FS_IntegrityVerificationSeed;
 
 /// Ext save data information.
-typedef struct LIBCTRU_PACKED
+typedef struct CTR_PACKED
 {
 	FS_MediaType mediaType : 8; ///< Media type.
 	u8 unknown;                 ///< Unknown.

--- a/libctru/include/3ds/types.h
+++ b/libctru/include/3ds/types.h
@@ -47,16 +47,16 @@ typedef void (*voidfn)(void);
 #define BIT(n) (1U<<(n))
 
 /// Aligns a struct (and other types?) to m, making sure that the size of the struct is a multiple of m.
-#define ALIGN(m)   __attribute__((aligned(m)))
+#define LIBCTRU_ALIGN(m)   __attribute__((aligned(m)))
 /// Packs a struct (and other types?) so it won't include padding bytes.
-#define PACKED     __attribute__((packed))
+#define LIBCTRU_PACKED     __attribute__((packed))
 
 #ifndef LIBCTRU_NO_DEPRECATION
 /// Flags a function as deprecated.
-#define DEPRECATED __attribute__ ((deprecated))
+#define LIBCTRU_DEPRECATED __attribute__ ((deprecated))
 #else
 /// Flags a function as deprecated.
-#define DEPRECATED
+#define LIBCTRU_DEPRECATED
 #endif
 
 /// Structure representing CPU registers
@@ -71,7 +71,7 @@ typedef struct {
 /// Structure representing FPU registers
 typedef struct {
 	union {
-		struct PACKED { double d[16]; }; ///< d0-d15.
+		struct LIBCTRU_PACKED { double d[16]; }; ///< d0-d15.
 		float  s[32];                    ///< s0-s31.
 	};
 	u32 fpscr;        ///< fpscr.

--- a/libctru/include/3ds/types.h
+++ b/libctru/include/3ds/types.h
@@ -47,16 +47,16 @@ typedef void (*voidfn)(void);
 #define BIT(n) (1U<<(n))
 
 /// Aligns a struct (and other types?) to m, making sure that the size of the struct is a multiple of m.
-#define LIBCTRU_ALIGN(m)   __attribute__((aligned(m)))
+#define CTR_ALIGN(m)   __attribute__((aligned(m)))
 /// Packs a struct (and other types?) so it won't include padding bytes.
-#define LIBCTRU_PACKED     __attribute__((packed))
+#define CTR_PACKED     __attribute__((packed))
 
-#ifndef LIBCTRU_NO_DEPRECATION
+#ifndef CTR_NO_DEPRECATION
 /// Flags a function as deprecated.
-#define LIBCTRU_DEPRECATED __attribute__ ((deprecated))
+#define CTR_DEPRECATED __attribute__ ((deprecated))
 #else
 /// Flags a function as deprecated.
-#define LIBCTRU_DEPRECATED
+#define CTR_DEPRECATED
 #endif
 
 /// Structure representing CPU registers
@@ -71,7 +71,7 @@ typedef struct {
 /// Structure representing FPU registers
 typedef struct {
 	union {
-		struct LIBCTRU_PACKED { double d[16]; }; ///< d0-d15.
+		struct CTR_PACKED { double d[16]; }; ///< d0-d15.
 		float  s[32];                    ///< s0-s31.
 	};
 	u32 fpscr;        ///< fpscr.

--- a/libctru/source/gdbhio.c
+++ b/libctru/source/gdbhio.c
@@ -205,7 +205,7 @@ static int _gdbExportSeekFlag(int flag)
 // https://sourceware.org/gdb/onlinedocs/gdb/struct-stat.html#struct-stat
 typedef u32 gdbhio_time_t;
 
-struct PACKED ALIGN(4) gdbhio_stat {
+struct LIBCTRU_PACKED LIBCTRU_ALIGN(4) gdbhio_stat {
 	u32  gst_dev;               /* device */
 	u32  gst_ino;               /* inode */
 	gdbhio_mode_t gst_mode;     /* protection */

--- a/libctru/source/gdbhio.c
+++ b/libctru/source/gdbhio.c
@@ -205,7 +205,7 @@ static int _gdbExportSeekFlag(int flag)
 // https://sourceware.org/gdb/onlinedocs/gdb/struct-stat.html#struct-stat
 typedef u32 gdbhio_time_t;
 
-struct LIBCTRU_PACKED LIBCTRU_ALIGN(4) gdbhio_stat {
+struct CTR_PACKED CTR_ALIGN(4) gdbhio_stat {
 	u32  gst_dev;               /* device */
 	u32  gst_ino;               /* inode */
 	gdbhio_mode_t gst_mode;     /* protection */

--- a/libctru/source/services/soc/soc_inet_pton.c
+++ b/libctru/source/services/soc/soc_inet_pton.c
@@ -6,7 +6,7 @@
 
 static int inet_pton4(const char *restrict src, void *restrict dst)
 {
-	u8 ip[4] LIBCTRU_ALIGN(4);
+	u8 ip[4] CTR_ALIGN(4);
 	if(sscanf(src,"%hhu.%hhu.%hhu.%hhu",&ip[0], &ip[1], &ip[2], &ip[3]) != 4) return 0;
 
 	memcpy(dst,ip,4);

--- a/libctru/source/services/soc/soc_inet_pton.c
+++ b/libctru/source/services/soc/soc_inet_pton.c
@@ -6,7 +6,7 @@
 
 static int inet_pton4(const char *restrict src, void *restrict dst)
 {
-	u8 ip[4] ALIGN(4);
+	u8 ip[4] LIBCTRU_ALIGN(4);
 	if(sscanf(src,"%hhu.%hhu.%hhu.%hhu",&ip[0], &ip[1], &ip[2], &ip[3]) != 4) return 0;
 
 	memcpy(dst,ip,4);


### PR DESCRIPTION
The mitigates compatibility issues with other libraries, such as the one seen in #530.

The `BIT` macro is kept because it is commonly used, so renaming it would be too breaking of a change (see
https://github.com/devkitPro/libctru/pull/531#issuecomment-1714148532)

Fixes #530