### PR TITLE
Fix NDMU_QueryStatus

### DIFF
--- a/libctru/include/3ds/services/ndm.h
+++ b/libctru/include/3ds/services/ndm.h
@@ -111,8 +111,9 @@ Result NDMU_ResumeScheduler(void);
 Result NDMU_GetCurrentState(ndmState *state);
 
 /**
- * @brief Returns the daemon state.
- * @param state Pointer to write the daemons state to.
+ * @brief Returns a daemon state.
+ * @param daemon The specified daemon.
+ * @param state Pointer to write the daemon state to.
  */
 Result NDMU_QueryStatus(ndmDaemon daemon, ndmDaemonStatus *status);
 

--- a/libctru/include/3ds/services/ndm.h
+++ b/libctru/include/3ds/services/ndm.h
@@ -114,7 +114,7 @@ Result NDMU_GetCurrentState(ndmState *state);
  * @brief Returns the daemon state.
  * @param state Pointer to write the daemons state to.
  */
-Result NDMU_QueryStatus(ndmDaemonStatus *status);
+Result NDMU_QueryStatus(ndmDaemon daemon, ndmDaemonStatus *status);
 
 /**
  * @brief Sets the scan interval.

--- a/libctru/source/services/ndm.c
+++ b/libctru/source/services/ndm.c
@@ -165,11 +165,12 @@ Result NDMU_GetCurrentState(ndmState *state)
 	return (Result)cmdbuf[1];
 }
 
-Result NDMU_QueryStatus(ndmDaemonStatus *status)
+Result NDMU_QueryStatus(ndmDaemon daemon, ndmDaemonStatus *status)
 {
 	u32* cmdbuf=getThreadCommandBuffer();
 
-	cmdbuf[0]=IPC_MakeHeader(0xD,1,0); // 0xD0000
+	cmdbuf[0]=IPC_MakeHeader(0xD,1,0); // 0xD0040
+	cmdbuf[1]=daemon;
 
 	Result ret=0;
 	if(R_FAILED(ret=svcSendSyncRequest(ndmuHandle)))return ret;


### PR DESCRIPTION
``NDMU_QueryStatus`` actually expects a daemon name in cmdbuf[1]

Example usage:

```c
ndmDaemonStatus status;
NDMU_QueryStatus(NDM_DAEMON_BOSS, &status);
	
if (status == NDM_DAEMON_STATUS_SUSPENDED) {
	// ...
}
```

As described here: https://www.3dbrew.org/wiki/NDMU:QueryStatus