### PR TITLE
Return the full length of `sockaddr_in` in socket functions with in/out addrlen

### DIFF
--- a/libctru/source/services/soc/soc_accept.c
+++ b/libctru/source/services/soc/soc_accept.c
@@ -61,9 +61,14 @@ int accept(int sockfd, struct sockaddr *addr, socklen_t *addrlen)
 
 	if(ret >= 0 && addr != NULL) {
 		addr->sa_family = tmpaddr[1];
-		if(*addrlen > tmpaddr[0])
-			*addrlen = tmpaddr[0];
-		memcpy(addr->sa_data, &tmpaddr[2], *addrlen - 2);
+
+		socklen_t user_addrlen = tmpaddr[0];
+		if(addr->sa_family == AF_INET)
+		    user_addrlen += 8; // Accounting for the 8 bytes of sin_zero padding, which must be written for compatibility.
+
+		if(*addrlen > user_addrlen)
+			*addrlen = user_addrlen;
+		memcpy(addr->sa_data, &tmpaddr[2], *addrlen - sizeof(addr->sa_family));
 	}
 
 	if(ret < 0) {

--- a/libctru/source/services/soc/soc_accept.c
+++ b/libctru/source/services/soc/soc_accept.c
@@ -6,10 +6,10 @@
 int accept(int sockfd, struct sockaddr *addr, socklen_t *addrlen)
 {
 	int ret = 0;
-	int tmp_addrlen = 0x1c;
+	int tmp_addrlen = ADDR_STORAGE_LEN;
 	int fd, dev;
 	u32 *cmdbuf = getThreadCommandBuffer();
-	u8 tmpaddr[0x1c];
+	u8 tmpaddr[ADDR_STORAGE_LEN];
 	u32 saved_threadstorage[2];
 
 	sockfd = soc_get_fd(sockfd);
@@ -27,7 +27,7 @@ int accept(int sockfd, struct sockaddr *addr, socklen_t *addrlen)
 	fd = __alloc_handle(dev);
 	if(fd < 0) return fd;
 
-	memset(tmpaddr, 0, 0x1c);
+	memset(tmpaddr, 0, ADDR_STORAGE_LEN);
 
 	cmdbuf[0] = IPC_MakeHeader(0x4,2,2); // 0x40082
 	cmdbuf[1] = (u32)sockfd;

--- a/libctru/source/services/soc/soc_bind.c
+++ b/libctru/source/services/soc/soc_bind.c
@@ -8,7 +8,7 @@ int bind(int sockfd, const struct sockaddr *addr, socklen_t addrlen)
 	int ret = 0;
 	int tmp_addrlen = 0;
 	u32 *cmdbuf = getThreadCommandBuffer();
-	u8 tmpaddr[0x1c];
+	u8 tmpaddr[ADDR_STORAGE_LEN];
 
 	sockfd = soc_get_fd(sockfd);
 	if(sockfd < 0) {
@@ -16,12 +16,12 @@ int bind(int sockfd, const struct sockaddr *addr, socklen_t addrlen)
 		return -1;
 	}
 
-	memset(tmpaddr, 0, 0x1c);
+	memset(tmpaddr, 0, ADDR_STORAGE_LEN);
 
 	if(addr->sa_family == AF_INET)
 		tmp_addrlen = 8;
 	else
-		tmp_addrlen = 0x1c;
+		tmp_addrlen = ADDR_STORAGE_LEN;
 
 	if(addrlen < tmp_addrlen) {
 		errno = EINVAL;

--- a/libctru/source/services/soc/soc_common.h
+++ b/libctru/source/services/soc/soc_common.h
@@ -10,6 +10,7 @@
 #include <3ds/services/soc.h>
 
 #define SYNC_ERROR ENODEV
+#define ADDR_STORAGE_LEN sizeof(struct sockaddr_storage)
 
 extern Handle	SOCU_handle;
 extern Handle	socMemhandle;

--- a/libctru/source/services/soc/soc_connect.c
+++ b/libctru/source/services/soc/soc_connect.c
@@ -8,7 +8,7 @@ int connect(int sockfd, const struct sockaddr *addr, socklen_t addrlen)
 	int ret = 0;
 	int tmp_addrlen = 0;
 	u32 *cmdbuf = getThreadCommandBuffer();
-	u8 tmpaddr[0x1c];
+	u8 tmpaddr[ADDR_STORAGE_LEN];
 
 	sockfd = soc_get_fd(sockfd);
 	if(sockfd < 0) {
@@ -16,12 +16,12 @@ int connect(int sockfd, const struct sockaddr *addr, socklen_t addrlen)
 		return -1;
 	}
 
-	memset(tmpaddr, 0, 0x1c);
+	memset(tmpaddr, 0, ADDR_STORAGE_LEN);
 
 	if(addr->sa_family == AF_INET)
 		tmp_addrlen = 8;
 	else
-		tmp_addrlen = 0x1c;
+		tmp_addrlen = ADDR_STORAGE_LEN;
 
 	if(addrlen < tmp_addrlen) {
 		errno = EINVAL;

--- a/libctru/source/services/soc/soc_getnameinfo.c
+++ b/libctru/source/services/soc/soc_getnameinfo.c
@@ -8,7 +8,7 @@ int getnameinfo(const struct sockaddr *sa, socklen_t salen, char *host, socklen_
 	int i,tmp_addrlen;
 	u32 *cmdbuf = getThreadCommandBuffer();
 	u32 saved_threadstorage[4];
-	u8 tmpaddr[0x1c]; // sockaddr size for the kernel is 0x1C (sockaddr_in6?)
+	u8 tmpaddr[ADDR_STORAGE_LEN]; // sockaddr size for the kernel is 0x1C (sockaddr_in6?)
 
 	if((host == NULL || hostlen == 0) && (serv == NULL || servlen == 0))
 	{
@@ -18,7 +18,7 @@ int getnameinfo(const struct sockaddr *sa, socklen_t salen, char *host, socklen_
 	if(sa->sa_family == AF_INET)
 		tmp_addrlen = 8;
 	else
-		tmp_addrlen = 0x1c;
+		tmp_addrlen = ADDR_STORAGE_LEN;
 
 	if(salen < tmp_addrlen) {
 		errno = EINVAL;

--- a/libctru/source/services/soc/soc_getpeername.c
+++ b/libctru/source/services/soc/soc_getpeername.c
@@ -16,6 +16,8 @@ int getpeername(int sockfd, struct sockaddr *addr, socklen_t *addrlen)
 		return -1;
 	}
 
+	memset(tmpaddr, 0, ADDR_STORAGE_LEN);
+
 	cmdbuf[0] = IPC_MakeHeader(0x18,2,2); // 0x180082
 	cmdbuf[1] = (u32)sockfd;
 	cmdbuf[2] = ADDR_STORAGE_LEN;
@@ -47,11 +49,15 @@ int getpeername(int sockfd, struct sockaddr *addr, socklen_t *addrlen)
 		return -1;
 	}
 
-	if(*addrlen > tmpaddr[0])
-		*addrlen = tmpaddr[0];
-	memset(addr, 0, sizeof(struct sockaddr));
 	addr->sa_family = tmpaddr[1];
-	memcpy(addr->sa_data, &tmpaddr[2], *addrlen - 2);
+
+	socklen_t user_addrlen = tmpaddr[0];
+	if(addr->sa_family == AF_INET)
+		user_addrlen += 8;
+
+	if(*addrlen > user_addrlen)
+		*addrlen = user_addrlen;
+	memcpy(addr->sa_data, &tmpaddr[2], *addrlen - sizeof(addr->sa_family));
 
 	return ret;
 }

--- a/libctru/source/services/soc/soc_getpeername.c
+++ b/libctru/source/services/soc/soc_getpeername.c
@@ -8,7 +8,7 @@ int getpeername(int sockfd, struct sockaddr *addr, socklen_t *addrlen)
 	int ret = 0;
 	u32 *cmdbuf = getThreadCommandBuffer();
 	u32 saved_threadstorage[2];
-	u8 tmpaddr[0x1c];
+	u8 tmpaddr[ADDR_STORAGE_LEN];
 
 	sockfd = soc_get_fd(sockfd);
 	if(sockfd < 0) {
@@ -18,14 +18,14 @@ int getpeername(int sockfd, struct sockaddr *addr, socklen_t *addrlen)
 
 	cmdbuf[0] = IPC_MakeHeader(0x18,2,2); // 0x180082
 	cmdbuf[1] = (u32)sockfd;
-	cmdbuf[2] = 0x1c;
+	cmdbuf[2] = ADDR_STORAGE_LEN;
 	cmdbuf[3] = IPC_Desc_CurProcessId();
 
 	u32 * staticbufs = getThreadStaticBuffers();
 	saved_threadstorage[0] = staticbufs[0];
 	saved_threadstorage[1] = staticbufs[1];
 
-	staticbufs[0] = IPC_Desc_StaticBuffer(0x1c,0);
+	staticbufs[0] = IPC_Desc_StaticBuffer(ADDR_STORAGE_LEN,0);
 	staticbufs[1] = (u32)tmpaddr;
 
 	ret = svcSendSyncRequest(SOCU_handle);

--- a/libctru/source/services/soc/soc_getsockname.c
+++ b/libctru/source/services/soc/soc_getsockname.c
@@ -8,7 +8,7 @@ int getsockname(int sockfd, struct sockaddr *addr, socklen_t *addrlen)
 	int ret = 0;
 	u32 *cmdbuf = getThreadCommandBuffer();
 	u32 saved_threadstorage[2];
-	u8 tmpaddr[0x1c];
+	u8 tmpaddr[ADDR_STORAGE_LEN];
 
 	sockfd = soc_get_fd(sockfd);
 	if(sockfd < 0)	{
@@ -18,14 +18,14 @@ int getsockname(int sockfd, struct sockaddr *addr, socklen_t *addrlen)
 
 	cmdbuf[0] = IPC_MakeHeader(0x17,2,2); // 0x170082
 	cmdbuf[1] = (u32)sockfd;
-	cmdbuf[2] = 0x1c;
+	cmdbuf[2] = ADDR_STORAGE_LEN;
 	cmdbuf[3] = IPC_Desc_CurProcessId();
 
 	u32 * staticbufs = getThreadStaticBuffers();
 	saved_threadstorage[0] = staticbufs[0];
 	saved_threadstorage[1] = staticbufs[1];
 
-	staticbufs[0] = IPC_Desc_StaticBuffer(0x1c,0);
+	staticbufs[0] = IPC_Desc_StaticBuffer(ADDR_STORAGE_LEN,0);
 	staticbufs[1] = (u32)tmpaddr;
 
 	ret = svcSendSyncRequest(SOCU_handle);

--- a/libctru/source/services/soc/soc_getsockname.c
+++ b/libctru/source/services/soc/soc_getsockname.c
@@ -16,6 +16,8 @@ int getsockname(int sockfd, struct sockaddr *addr, socklen_t *addrlen)
 		return -1;
 	}
 
+	memset(tmpaddr, 0, ADDR_STORAGE_LEN);
+
 	cmdbuf[0] = IPC_MakeHeader(0x17,2,2); // 0x170082
 	cmdbuf[1] = (u32)sockfd;
 	cmdbuf[2] = ADDR_STORAGE_LEN;
@@ -47,11 +49,15 @@ int getsockname(int sockfd, struct sockaddr *addr, socklen_t *addrlen)
 		return -1;
 	}
 
-	if(*addrlen > tmpaddr[0])
-		*addrlen = tmpaddr[0];
-	memset(addr, 0, sizeof(struct sockaddr));
 	addr->sa_family = tmpaddr[1];
-	memcpy(addr->sa_data, &tmpaddr[2], *addrlen - 2);
+
+	socklen_t user_addrlen = tmpaddr[0];
+	if(addr->sa_family == AF_INET)
+		user_addrlen += 8;
+
+	if(*addrlen > user_addrlen)
+		*addrlen = user_addrlen;
+	memcpy(addr->sa_data, &tmpaddr[2], *addrlen - sizeof(addr->sa_family));
 
 	return ret;
 }

--- a/libctru/source/services/soc/soc_recvfrom.c
+++ b/libctru/source/services/soc/soc_recvfrom.c
@@ -53,9 +53,14 @@ ssize_t socuipc_cmd7(int sockfd, void *buf, size_t len, int flags, struct sockad
 
 	if(src_addr != NULL) {
 		src_addr->sa_family = tmpaddr[1];
-		if(*addrlen > tmpaddr[0])
-			*addrlen = tmpaddr[0];
-		memcpy(src_addr->sa_data, &tmpaddr[2], *addrlen - 2);
+
+		socklen_t user_addrlen = tmpaddr[0];
+		if(src_addr->sa_family == AF_INET)
+			user_addrlen += 8;
+
+		if(*addrlen > user_addrlen)
+			*addrlen = user_addrlen;
+		memcpy(src_addr->sa_data, &tmpaddr[2], *addrlen - sizeof(src_addr->sa_family));
 	}
 
 	return ret;
@@ -113,9 +118,14 @@ ssize_t socuipc_cmd8(int sockfd, void *buf, size_t len, int flags, struct sockad
 
 	if(src_addr != NULL) {
 		src_addr->sa_family = tmpaddr[1];
-		if(*addrlen > tmpaddr[0])
-			*addrlen = tmpaddr[0];
-		memcpy(src_addr->sa_data, &tmpaddr[2], *addrlen - 2);
+
+		socklen_t user_addrlen = tmpaddr[0];
+		if(src_addr->sa_family == AF_INET)
+			user_addrlen += 8;
+
+		if(*addrlen > user_addrlen)
+			*addrlen = user_addrlen;
+		memcpy(src_addr->sa_data, &tmpaddr[2], *addrlen - sizeof(src_addr->sa_family));
 	}
 
 	return ret;

--- a/libctru/source/services/soc/soc_recvfrom.c
+++ b/libctru/source/services/soc/soc_recvfrom.c
@@ -8,13 +8,13 @@ ssize_t socuipc_cmd7(int sockfd, void *buf, size_t len, int flags, struct sockad
 	int ret = 0;
 	u32 *cmdbuf = getThreadCommandBuffer();
 	u32 tmp_addrlen = 0;
-	u8 tmpaddr[0x1c];
+	u8 tmpaddr[ADDR_STORAGE_LEN];
 	u32 saved_threadstorage[2];
 
-	memset(tmpaddr, 0, 0x1c);
+	memset(tmpaddr, 0, ADDR_STORAGE_LEN);
 
 	if(src_addr)
-		tmp_addrlen = 0x1c;
+		tmp_addrlen = ADDR_STORAGE_LEN;
 
 	cmdbuf[0] = IPC_MakeHeader(0x7,4,4); // 0x70104
 	cmdbuf[1] = (u32)sockfd;
@@ -66,13 +66,13 @@ ssize_t socuipc_cmd8(int sockfd, void *buf, size_t len, int flags, struct sockad
 	int ret = 0;
 	u32 *cmdbuf = getThreadCommandBuffer();
 	u32 tmp_addrlen = 0;
-	u8 tmpaddr[0x1c];
+	u8 tmpaddr[ADDR_STORAGE_LEN];
 	u32 saved_threadstorage[4];
 
 	if(src_addr)
-		tmp_addrlen = 0x1c;
+		tmp_addrlen = ADDR_STORAGE_LEN;
 
-	memset(tmpaddr, 0, 0x1c);
+	memset(tmpaddr, 0, ADDR_STORAGE_LEN);
 
 	cmdbuf[0] = 0x00080102;
 	cmdbuf[1] = (u32)sockfd;

--- a/libctru/source/services/soc/soc_sendto.c
+++ b/libctru/source/services/soc/soc_sendto.c
@@ -8,15 +8,15 @@ ssize_t socuipc_cmd9(int sockfd, const void *buf, size_t len, int flags, const s
 	int ret = 0;
 	u32 *cmdbuf = getThreadCommandBuffer();
 	u32 tmp_addrlen = 0;
-	u8 tmpaddr[0x1c];
+	u8 tmpaddr[ADDR_STORAGE_LEN];
 
-	memset(tmpaddr, 0, 0x1c);
+	memset(tmpaddr, 0, ADDR_STORAGE_LEN);
 
 	if(dest_addr) {
 		if(dest_addr->sa_family == AF_INET)
 			tmp_addrlen = 8;
 		else
-			tmp_addrlen = 0x1c;
+			tmp_addrlen = ADDR_STORAGE_LEN;
 
 		if(addrlen < tmp_addrlen) {
 			errno = EINVAL;
@@ -62,15 +62,15 @@ ssize_t socuipc_cmda(int sockfd, const void *buf, size_t len, int flags, const s
 	int ret = 0;
 	u32 *cmdbuf = getThreadCommandBuffer();
 	u32 tmp_addrlen = 0;
-	u8 tmpaddr[0x1c];
+	u8 tmpaddr[ADDR_STORAGE_LEN];
 
-	memset(tmpaddr, 0, 0x1c);
+	memset(tmpaddr, 0, ADDR_STORAGE_LEN);
 
 	if(dest_addr) {
 		if(dest_addr->sa_family == AF_INET)
 			tmp_addrlen = 8;
 		else
-			tmp_addrlen = 0x1c;
+			tmp_addrlen = ADDR_STORAGE_LEN;
 
 		if(addrlen < tmp_addrlen) {
 			errno = EINVAL;


### PR DESCRIPTION
Relevant links: https://github.com/rust3ds/ctru-rs/issues/174, [discussion on courses of action](https://github.com/Meziu/rust-horizon/commit/96b0f4c2d3f61863b1499037d3a738f73cb4511a#r145611578), [original change in libc crate](https://github.com/rust-lang/libc/pull/2725), [problematic test](https://github.com/rust-lang/rust/blob/38e3a5771cefc9362976a605549f8b04d5707311/library/std/src/sys_common/net.rs#L113).
CC: @ian-h-chamberlain @adryzz @AzureMarker

The kernel implementation of `sockaddr` data, used by all `soc` services, is composed of 8 bytes of data. While this is true, the `sockaddr_in` definition exposed by libctru is more closely related to the corresponding Linux (and many other systems') definition, having an additional 8 byte padding field (`sin_zero`). This is a generally favorable design decision for compatibility with most *nix software. However, unlike most Posix-complying implementations, the current implementation in `libctru` only handles the transfer of the 8 bytes actually manipulated by the OS.

This particularity imposes 2 "differentiating" factors that may hinder compatiblity with code written for standard *nix platforms:
1. The padding field is never (internally) overwritten to be actually zeroed. In most situations that means that programs passing in a pointer to `sockaddr_in` memory are left with uninitialized data (not a big deal since that memory isn't responsibility of `libctru`). This also shouldn't be a problem since the implementation of functions with an in/out `*addrlen` argument correctly specify that only the first 8 bytes were modified (also, `sin_zero` isn't supposed to ever be read).
2. The returned length, as specified above being always 8 bytes, is less than the size of the `sockaddr_in` structure (16 bytes), meaning that programs expecting the size given to be the same as the output will be unpleasantly surprised when they find out the `sockaddr_in` struct is "unexpectedly" oversized. For this reason (and for the fact that `sin_zero` is a fundamentally important field for most implementations), platforms such as Linux actually return the full 16 byte length, taking into consideration those 8 trailing bytes. This isn't done by `libctru`, which only returns a socket address length of 8.

I am fully aware that this is basically a non-existent problem, and as far as I can tell, the Posix standard isn't even broken by having an oversized `sockaddr_in` definition, since data length issues are to be resolved using the `*addrlen` parameter, and not by "expecting" sizes and lengths to be that of data structures. However, and the case that prompted this change is proof of this, this situation is not really expected to be handled by most programs, which instead believe the platform's socket implementation has to account for the full memory mapping (which is something they usually do).

The possible fixes for this problem are:
- Do nothing about it. (not cool)
- Remove the `sin_zero` field from the `libctru` definition and more thinly wrap the kernel implementation. (might break backward and cross compatibility)
- Return the full length of `sockaddr_in` for successful calls to socket functions. Since this is the solution which requires the most changes, I've taken the liberty to include such changes in this PR.

This PR doesn't have to be merged or closed as-is. Please take the time to discuss the issue further if this is not what you intend on using.
