### PR TITLE
apt: Added aptClearHomePressRejected func

### DIFF
--- a/libctru/include/3ds/services/apt.h
+++ b/libctru/include/3ds/services/apt.h
@@ -175,6 +175,9 @@ bool aptShouldJumpToHome(void);
 /// Returns true if there is an incoming HOME button press rejected by the policy set by \ref aptSetHomeAllowed (use this to show a "no HOME allowed" icon).
 bool aptCheckHomePressRejected(void);
 
+/// Clear the incoming HOME button press rejected flag.
+void aptClearHomePressRejected(void);
+
 /// \deprecated Alias for \ref aptCheckHomePressRejected.
 static inline CTR_DEPRECATED bool aptIsHomePressed(void)
 {

--- a/libctru/source/services/apt.c
+++ b/libctru/source/services/apt.c
@@ -308,6 +308,12 @@ bool aptCheckHomePressRejected(void)
 	return false;
 }
 
+void aptClearHomePressRejected(void)
+{
+	if (aptFlags & FLAG_HOMEREJECTED)
+		aptFlags &= ~FLAG_HOMEREJECTED;
+}
+
 static void aptClearJumpToHome(void)
 {
 	aptHomeButtonState = 0;


### PR DESCRIPTION
This will allow the user to manually clear the FLAG_HOMEREJECTED flag.
If the user presses the home button multiple times (assuming aptSetHomeAllowed(false) has been executed), the FLAG_HOMEREJECTED flag is repeatedly enabled, which may cause repeated responses.
In such a scenario, I think manually clearing FLAG_HOMEREJECTED flag becomes very useful.