### PR TITLE
apt: Add aptLaunchSystemApplet

### DIFF
--- a/libctru/include/3ds/services/apt.h
+++ b/libctru/include/3ds/services/apt.h
@@ -227,6 +227,15 @@ void aptSetMessageCallback(aptMessageCb callback, void* user);
  */
 void aptLaunchLibraryApplet(NS_APPID appId, void* buf, size_t bufsize, Handle handle);
 
+/**
+ * @brief Launches a system applet.
+ * @param appId ID of the applet to launch.
+ * @param buf Input/output buffer that contains launch parameters on entry and result data on exit.
+ * @param bufsize Size of the buffer.
+ * @param handle Handle to pass to the system applet.
+ */
+void aptLaunchSystemApplet(NS_APPID appId, void* buf, size_t bufsize, Handle handle);
+
 /// Clears the chainloader state.
 void aptClearChainloader(void);
 

--- a/libctru/source/services/apt.c
+++ b/libctru/source/services/apt.c
@@ -920,13 +920,14 @@ void aptLaunchSystemApplet(NS_APPID appId, void* buf, size_t bufsize, Handle han
 
 	aptCallHook(APTHOOK_ONSUSPEND);
 
+	GSPGPU_SaveVramSysArea();
+	GSPGPU_ReleaseRight();
+
 	aptSetSleepAllowed(false);
 	APT_StartSystemApplet(appId, buf, bufsize, handle);
 	aptFlags &= ~FLAG_ACTIVE;
 
-	GSPGPU_SaveVramSysArea();
 	aptScreenTransfer(appId, true);
-	GSPGPU_ReleaseRight();
 
 	aptWaitForWakeUp(TR_SYSAPPLET);
 	memcpy(buf, aptParameters, bufsize);


### PR DESCRIPTION
Needed for launching system applets like the Miiverse posting applet "solv3". The screen transfer is expected to be done after launching the applet.