### PR TITLE
fix: Sleep and wake up dsp when calling a system applet

### DIFF
--- a/libctru/source/services/apt.c
+++ b/libctru/source/services/apt.c
@@ -921,6 +921,7 @@ void aptLaunchSystemApplet(NS_APPID appId, void* buf, size_t bufsize, Handle han
 	aptCallHook(APTHOOK_ONSUSPEND);
 
 	GSPGPU_SaveVramSysArea();
+	aptDspSleep();
 	GSPGPU_ReleaseRight();
 
 	aptSetSleepAllowed(false);


### PR DESCRIPTION
In https://github.com/devkitPro/libctru/commit/a88ab665a83fd15483b4da9760631965ebeef092 a new method `aptLaunchSystemApplet` was added. This, however, does not pause / wake up the DSP, if it is in use. This is required, else the applet may do a fantastic crash (e.g. browser applet).

This PR fixes this by calling the respective methods.

This has been tested with the browser applet both while using and while not using dsp.