### PR TITLE
Include act header in 3ds.h

### DIFF
--- a/libctru/include/3ds.h
+++ b/libctru/include/3ds.h
@@ -35,6 +35,7 @@ extern "C" {
 #include <3ds/allocator/vram.h>
 
 #include <3ds/services/ac.h>
+#include <3ds/services/act.h>
 #include <3ds/services/am.h>
 #include <3ds/services/ampxi.h>
 #include <3ds/services/apt.h>


### PR DESCRIPTION
Hey guys, regarding this [pull request](https://github.com/devkitPro/libctru/pull/558). I guess we missed adding 3ds/services/act.h in 3ds.h. This PR basically includes that header in the main header file.