### PR TITLE
Implemented mvdstdCalculateBufferSize()

### DIFF
--- a/libctru/include/3ds/services/mvd.h
+++ b/libctru/include/3ds/services/mvd.h
@@ -167,7 +167,7 @@ void mvdstdExit(void);
 
 /**
  * @brief Calculate working buffer size for H.264 decoding.
- * @param config Calculation config, see here for detailed explanations : https://www.3dbrew.org/wiki/MVDSTD:CalculateWorkBufSize.
+ * @param config Calculation config, config->level.level must NOT exceed MVD_H264_LEVEL_5_2. See here for more explanations : https://www.3dbrew.org/wiki/MVDSTD:CalculateWorkBufSize.
  * @param size_out Calculated buffer size in bytes.
  */
 Result mvdstdCalculateBufferSize(const MVDSTD_CalculateWorkBufSizeConfig* config, u32* size_out);

--- a/libctru/include/3ds/services/mvd.h
+++ b/libctru/include/3ds/services/mvd.h
@@ -20,28 +20,28 @@
 /// Default input size for mvdstdInit(). This is what the New3DS Internet Browser uses, from the MVDSTD:CalculateWorkBufSize output.
 #define MVD_DEFAULT_WORKBUF_SIZE 0x9006C8
 
-#define MVD_CALC_WITH_LEVEL_FLAG_NONE				(u8)(0x00)	//Nothing.
-#define MVD_CALC_WITH_LEVEL_FLAG_ENABLE_CALC		(u8)(0x01)	//Enable calculation with level.
-#define MVD_CALC_WITH_LEVEL_FLAG_ENABLE_EXTRA_OP	(u8)(0x02)	//Enable extra op after base calculation (see : https://www.3dbrew.org/wiki/MVDSTD:CalculateWorkBufSize).
-#define MVD_CALC_WITH_LEVEL_FLAG_UNK				(u8)(0x04)	//Unknown.
+#define MVD_CALC_WITH_LEVEL_FLAG_NONE				0x00	//Nothing.
+#define MVD_CALC_WITH_LEVEL_FLAG_ENABLE_CALC		0x01	//Enable calculation with level.
+#define MVD_CALC_WITH_LEVEL_FLAG_ENABLE_EXTRA_OP	0x02	//Enable extra op after base calculation (see : https://www.3dbrew.org/wiki/MVDSTD:CalculateWorkBufSize.
+#define MVD_CALC_WITH_LEVEL_FLAG_UNK				0x04	//Unknown.
 
-#define MVD_H264_LEVEL_1_0		(u8)(0x00)	//H.264 level 1.0.
-#define MVD_H264_LEVEL_1_0B		(u8)(0x01)	//H.264 level 1.0b.
-#define MVD_H264_LEVEL_1_1		(u8)(0x02)	//H.264 level 1.1.
-#define MVD_H264_LEVEL_1_2		(u8)(0x03)	//H.264 level 1.2.
-#define MVD_H264_LEVEL_1_3		(u8)(0x04)	//H.264 level 1.3.
-#define MVD_H264_LEVEL_2_0		(u8)(0x05)	//H.264 level 2.0.
-#define MVD_H264_LEVEL_2_1		(u8)(0x06)	//H.264 level 2.1.
-#define MVD_H264_LEVEL_2_2		(u8)(0x07)	//H.264 level 2.2.
-#define MVD_H264_LEVEL_3_0		(u8)(0x08)	//H.264 level 3.0.
-#define MVD_H264_LEVEL_3_1		(u8)(0x09)	//H.264 level 3.1.
-#define MVD_H264_LEVEL_3_2		(u8)(0x0A)	//H.264 level 3.2.
-#define MVD_H264_LEVEL_4_0		(u8)(0x0B)	//H.264 level 4.0.
-#define MVD_H264_LEVEL_4_1		(u8)(0x0C)	//H.264 level 4.1.
-#define MVD_H264_LEVEL_4_2		(u8)(0x0D)	//H.264 level 4.2.
-#define MVD_H264_LEVEL_5_0		(u8)(0x0E)	//H.264 level 5.0.
-#define MVD_H264_LEVEL_5_1		(u8)(0x0F)	//H.264 level 5.1.
-#define MVD_H264_LEVEL_5_2		(u8)(0x10)	//H.264 level 5.2.
+#define MVD_H264_LEVEL_1_0		0x00	//H.264 level 1.0.
+#define MVD_H264_LEVEL_1_0B		0x01	//H.264 level 1.0b.
+#define MVD_H264_LEVEL_1_1		0x02	//H.264 level 1.1.
+#define MVD_H264_LEVEL_1_2		0x03	//H.264 level 1.2.
+#define MVD_H264_LEVEL_1_3		0x04	//H.264 level 1.3.
+#define MVD_H264_LEVEL_2_0		0x05	//H.264 level 2.0.
+#define MVD_H264_LEVEL_2_1		0x06	//H.264 level 2.1.
+#define MVD_H264_LEVEL_2_2		0x07	//H.264 level 2.2.
+#define MVD_H264_LEVEL_3_0		0x08	//H.264 level 3.0.
+#define MVD_H264_LEVEL_3_1		0x09	//H.264 level 3.1.
+#define MVD_H264_LEVEL_3_2		0x0A	//H.264 level 3.2.
+#define MVD_H264_LEVEL_4_0		0x0B	//H.264 level 4.0.
+#define MVD_H264_LEVEL_4_1		0x0C	//H.264 level 4.1.
+#define MVD_H264_LEVEL_4_2		0x0D	//H.264 level 4.2.
+#define MVD_H264_LEVEL_5_0		0x0E	//H.264 level 5.0.
+#define MVD_H264_LEVEL_5_1		0x0F	//H.264 level 5.1.
+#define MVD_H264_LEVEL_5_2		0x10	//H.264 level 5.2.
 
 /// Processing mode.
 typedef enum {

--- a/libctru/include/3ds/services/mvd.h
+++ b/libctru/include/3ds/services/mvd.h
@@ -170,7 +170,7 @@ void mvdstdExit(void);
  * @param config Calculation config, see here for detailed explanations : https://www.3dbrew.org/wiki/MVDSTD:CalculateWorkBufSize.
  * @param size_out Calculated buffer size in bytes.
  */
-Result mvdstdCalculateBufferSize(MVDSTD_CalculateWorkBufSizeConfig* config, u32* size_out);
+Result mvdstdCalculateBufferSize(const MVDSTD_CalculateWorkBufSizeConfig* config, u32* size_out);
 
 /**
  * @brief Generates a default MVDSTD configuration.

--- a/libctru/include/3ds/services/mvd.h
+++ b/libctru/include/3ds/services/mvd.h
@@ -124,7 +124,7 @@ typedef struct
 	u8 enable;			//Whether use this calculation method.
 	u8 flag;			//Flag for calculation (MVD_CALC_WITH_LEVEL_FLAG_XXXXXX).
 	u8 double_size;		//If set, size calculation result is doubled.
-	u8 level;			//H.264 (AVC) level (MVD_H264_LEVEL_XXXXXX).
+	u8 level;			//H.264 (AVC) level (MVD_H264_LEVEL_1_0 ~ MVD_H264_LEVEL_5_2).
 } MVDSTD_WithLevel;
 
 typedef struct

--- a/libctru/include/3ds/services/mvd.h
+++ b/libctru/include/3ds/services/mvd.h
@@ -96,6 +96,39 @@ typedef struct {
 	u8 cmd1b_inval;
 } MVDSTD_InitStruct;
 
+typedef struct
+{
+	u8 enable;			//Whether use this calculation method.
+	u8 flag;			//Flag for calculation.
+	u8 double_size;		//If set, size calculation result is doubled.
+	u8 level;			//H.264 (AVC) level.
+} MVDSTD_WithLevel;
+
+typedef struct
+{
+	u8 enable;			//Whether use this calculation method.
+	u8 ref_frames;		//Number of reference frames.
+} MVDSTD_WithNumOfRefFrames;
+
+/// H.264 buffer calculation configuration.
+/// See here for detailed explanations : https://www.3dbrew.org/wiki/MVDSTD:CalculateWorkBufSize.
+typedef struct {
+	u8 unused_0x00;								//Unused.
+	MVDSTD_WithLevel level;						//Calc buffer size with H.264 level.
+	MVDSTD_WithNumOfRefFrames ref_frames_a;		//Calc buffer size with num of reference frames and resolution.
+	MVDSTD_WithNumOfRefFrames ref_frames_b;		//Calc buffer size with num of reference frames and resolution.
+	u8 unused_0x09[3];							//Unused.
+	u32 unk_0x0c;								//Unknown.
+	u32 unk_0x10;								//Unknown.
+	u32 unk_0x14;								//Unknown.
+	u32 unk_0x18;								//Unknown.
+	u32 unk_0x1c;								//Unknown.
+	u32 unk_0x20;								//Unknown.
+	u32 unk_0x24;								//Unknown.
+	u32 width;									//Video width.
+	u32 height;									//Video height.
+} MVDSTD_CalculateWorkBufSizeConfig;
+
 /**
  * @brief Initializes MVDSTD.
  * @param mode Mode to initialize MVDSTD to.
@@ -108,6 +141,13 @@ Result mvdstdInit(MVDSTD_Mode mode, MVDSTD_InputFormat input_type, MVDSTD_Output
 
 /// Shuts down MVDSTD.
 void mvdstdExit(void);
+
+/**
+ * @brief Calculate working buffer size for H.264 decoding.
+ * @param config Calculation config, see here for detailed explanations : https://www.3dbrew.org/wiki/MVDSTD:CalculateWorkBufSize.
+ * @param size_out Calculated buffer size in bytes.
+ */
+Result mvdstdCalculateBufferSize(MVDSTD_CalculateWorkBufSizeConfig* config, u32* size_out);
 
 /**
  * @brief Generates a default MVDSTD configuration.

--- a/libctru/include/3ds/services/mvd.h
+++ b/libctru/include/3ds/services/mvd.h
@@ -20,6 +20,29 @@
 /// Default input size for mvdstdInit(). This is what the New3DS Internet Browser uses, from the MVDSTD:CalculateWorkBufSize output.
 #define MVD_DEFAULT_WORKBUF_SIZE 0x9006C8
 
+#define MVD_CALC_WITH_LEVEL_FLAG_NONE				(u8)(0x00)	//Nothing.
+#define MVD_CALC_WITH_LEVEL_FLAG_ENABLE_CALC		(u8)(0x01)	//Enable calculation with level.
+#define MVD_CALC_WITH_LEVEL_FLAG_ENABLE_EXTRA_OP	(u8)(0x02)	//Enable extra op after base calculation (see : https://www.3dbrew.org/wiki/MVDSTD:CalculateWorkBufSize).
+#define MVD_CALC_WITH_LEVEL_FLAG_UNK				(u8)(0x04)	//Unknown.
+
+#define MVD_H264_LEVEL_1_0		(u8)(0x00)	//H.264 level 1.0.
+#define MVD_H264_LEVEL_1_0B		(u8)(0x01)	//H.264 level 1.0b.
+#define MVD_H264_LEVEL_1_1		(u8)(0x02)	//H.264 level 1.1.
+#define MVD_H264_LEVEL_1_2		(u8)(0x03)	//H.264 level 1.2.
+#define MVD_H264_LEVEL_1_3		(u8)(0x04)	//H.264 level 1.3.
+#define MVD_H264_LEVEL_2_0		(u8)(0x05)	//H.264 level 2.0.
+#define MVD_H264_LEVEL_2_1		(u8)(0x06)	//H.264 level 2.1.
+#define MVD_H264_LEVEL_2_2		(u8)(0x07)	//H.264 level 2.2.
+#define MVD_H264_LEVEL_3_0		(u8)(0x08)	//H.264 level 3.0.
+#define MVD_H264_LEVEL_3_1		(u8)(0x09)	//H.264 level 3.1.
+#define MVD_H264_LEVEL_3_2		(u8)(0x0A)	//H.264 level 3.2.
+#define MVD_H264_LEVEL_4_0		(u8)(0x0B)	//H.264 level 4.0.
+#define MVD_H264_LEVEL_4_1		(u8)(0x0C)	//H.264 level 4.1.
+#define MVD_H264_LEVEL_4_2		(u8)(0x0D)	//H.264 level 4.2.
+#define MVD_H264_LEVEL_5_0		(u8)(0x0E)	//H.264 level 5.0.
+#define MVD_H264_LEVEL_5_1		(u8)(0x0F)	//H.264 level 5.1.
+#define MVD_H264_LEVEL_5_2		(u8)(0x10)	//H.264 level 5.2.
+
 /// Processing mode.
 typedef enum {
 	MVDMODE_COLORFORMATCONV, ///< Converting color formats.
@@ -99,9 +122,9 @@ typedef struct {
 typedef struct
 {
 	u8 enable;			//Whether use this calculation method.
-	u8 flag;			//Flag for calculation.
+	u8 flag;			//Flag for calculation (MVD_CALC_WITH_LEVEL_FLAG_XXXXXX).
 	u8 double_size;		//If set, size calculation result is doubled.
-	u8 level;			//H.264 (AVC) level.
+	u8 level;			//H.264 (AVC) level (MVD_H264_LEVEL_XXXXXX).
 } MVDSTD_WithLevel;
 
 typedef struct

--- a/libctru/source/services/mvd.c
+++ b/libctru/source/services/mvd.c
@@ -52,7 +52,7 @@ static Result MVDSTD_Shutdown(void)
 	return cmdbuf[1];
 }
 
-static Result MVDSTD_CalculateWorkBufSize(MVDSTD_CalculateWorkBufSizeConfig* config, u32* size_out)
+static Result MVDSTD_CalculateWorkBufSize(const MVDSTD_CalculateWorkBufSizeConfig* config, u32* size_out)
 {
 	Result ret=0;
 	u32* cmdbuf = getThreadCommandBuffer();
@@ -327,7 +327,7 @@ void mvdstdExit(void)
 	linearFree(mvdstd_workbuf);
 }
 
-Result mvdstdCalculateBufferSize(MVDSTD_CalculateWorkBufSizeConfig* config, u32* size_out)
+Result mvdstdCalculateBufferSize(const MVDSTD_CalculateWorkBufSizeConfig* config, u32* size_out)
 {
 	bool must_close_handle = false;
 	Result ret = 0;

--- a/libctru/source/services/mvd.c
+++ b/libctru/source/services/mvd.c
@@ -332,7 +332,7 @@ Result mvdstdCalculateBufferSize(MVDSTD_CalculateWorkBufSizeConfig* config, u32*
 	bool must_close_handle = false;
 	Result ret = 0;
 
-	if(!config || !size_out)
+	if(!config || !size_out || config->level.level > 0x10)
 		return -1;
 
 	//If we don't have mvdstd handle, get it.
@@ -343,11 +343,6 @@ Result mvdstdCalculateBufferSize(MVDSTD_CalculateWorkBufSizeConfig* config, u32*
 
 		must_close_handle = true;
 	}
-
-	//Attempting to use more than 0x10 for H.264 level will likely cause out-of-bound access. 
-	//https://www.3dbrew.org/wiki/MVDSTD:CalculateWorkBufSize
-	if(config->level.level > 0x10)
-		config->level.level = 0x10;
 
 	ret = MVDSTD_CalculateWorkBufSize(config, size_out);
 

--- a/libctru/source/services/mvd.c
+++ b/libctru/source/services/mvd.c
@@ -14,7 +14,9 @@
 #include <3ds/services/mvd.h>
 #include <3ds/ipc.h>
 
-Handle mvdstdHandle;
+#define CALC_BUF_SIZE_SAFETY_MARGIN			(u16)(4096)
+
+Handle mvdstdHandle = 0;
 static int mvdstdRefCount;
 static MVDSTD_Mode mvdstd_mode;
 static MVDSTD_InputFormat mvdstd_input_type;
@@ -46,6 +48,20 @@ static Result MVDSTD_Shutdown(void)
 
 	Result ret=0;
 	if((ret = svcSendSyncRequest(mvdstdHandle)))return ret;
+
+	return cmdbuf[1];
+}
+
+static Result MVDSTD_CalculateWorkBufSize(MVDSTD_CalculateWorkBufSizeConfig* config, u32* size_out)
+{
+	Result ret=0;
+	u32* cmdbuf = getThreadCommandBuffer();
+
+	cmdbuf[0] = IPC_MakeHeader(0x3,12,0); // 0x30300
+	memcpy(&cmdbuf[1], config, sizeof(MVDSTD_OutputBuffersEntryList));
+
+	if(R_FAILED(ret=svcSendSyncRequest(mvdstdHandle)))return ret;
+	if(size_out) *size_out = cmdbuf[2];
 
 	return cmdbuf[1];
 }
@@ -219,7 +235,9 @@ Result mvdstdInit(MVDSTD_Mode mode, MVDSTD_InputFormat input_type, MVDSTD_Output
 {
 	Result ret=0, ret2=0;
 
-	mvdstd_workbufsize = size;
+	//It seems there is some buffer overflow (some hundreds bytes according to test)
+	//when maximum number of reference frames are used : https://www.3dbrew.org/wiki/MVDSTD:CalculateWorkBufSize
+	mvdstd_workbufsize = (size + CALC_BUF_SIZE_SAFETY_MARGIN);
 	mvdstd_mode = mode;
 	mvdstd_input_type = input_type;
 	mvdstd_output_type = output_type;
@@ -304,8 +322,43 @@ void mvdstdExit(void)
 	MVDSTD_Shutdown();
 
 	svcCloseHandle(mvdstdHandle);
+	mvdstdHandle = 0;
 
 	linearFree(mvdstd_workbuf);
+}
+
+Result mvdstdCalculateBufferSize(MVDSTD_CalculateWorkBufSizeConfig* config, u32* size_out)
+{
+	bool must_close_handle = false;
+	Result ret = 0;
+
+	if(!config || !size_out)
+		return -1;
+
+	//If we don't have mvdstd handle, get it.
+	if(mvdstdHandle == 0)
+	{
+		if(R_FAILED(ret=srvGetServiceHandle(&mvdstdHandle, "mvd:STD")))
+			return ret;
+
+		must_close_handle = true;
+	}
+
+	//Attempting to use more than 0x10 for H.264 level will likely cause out-of-bound access. 
+	//https://www.3dbrew.org/wiki/MVDSTD:CalculateWorkBufSize
+	if(config->level.level > 0x10)
+		config->level.level = 0x10;
+
+	ret = MVDSTD_CalculateWorkBufSize(config, size_out);
+
+	//Release handle if we must do so.
+	if(must_close_handle)
+	{
+		svcCloseHandle(mvdstdHandle);
+		mvdstdHandle = 0;
+	}
+
+	return ret;
 }
 
 void mvdstdGenerateDefaultConfig(MVDSTD_Config*config, u32 input_width, u32 input_height, u32 output_width, u32 output_height, u32 *vaddr_colorconv_indata, u32 *vaddr_outdata0, u32 *vaddr_outdata1)


### PR DESCRIPTION
I've [analyzed](https://www.3dbrew.org/wiki/MVDSTD:CalculateWorkBufSize) and implemented `mvdstdCalculateBufferSize()` to calculate working buffer size for H.264 video decoding on MVD based on video (resolution/H.264 level etc...).

Currently we don't have any way to calculate working buffer size, so only way to use MVD is just use `MVD_DEFAULT_WORKBUF_SIZE` (or ~~maybe just put random value to check if it works for your video~~), it's fine if you want to decode (most of) 480p videos.

However that doesn't mean MVD can't decode more than that (actually it **can** decode 1080p if enough buffer is provided) so we should also have a way to calculate it, this can also be used to calculate smaller size for lower resolution/level videos.