### PR TITLE
avoid reserved keyword `operator` in ACTA_ReserveTransfer

### DIFF
--- a/libctru/include/3ds/services/act.h
+++ b/libctru/include/3ds/services/act.h
@@ -917,11 +917,11 @@ Result ACTA_SetIsMiiUpdated(u8 accountSlot, bool isDirty);
  * @brief Initializes a server account transfer of a specific account to another device.
  * @param accountSlot The account slot number of the account to transfer the server account of.
  * @param newDevice Pointer to device info of the target device.
- * @param operator Pointer to operator data for the transfer.
+ * @param operatorData Pointer to operator data for the transfer.
  * @param operatorSize Size of the operator data buffer (max: 0x100)
  * @param completionEvent The event handle to signal once the request has finished.
  */
-Result ACTA_ReserveTransfer(u8 accountSlot, DeviceInfo *newDevice, char *operator, u32 operatorSize, Handle completionEvent);
+Result ACTA_ReserveTransfer(u8 accountSlot, DeviceInfo *newDevice, char *operatorData, u32 operatorSize, Handle completionEvent);
 
 /**
  * @brief Finalizes a server account transfer of a specifc account to another device.

--- a/libctru/source/services/act.c
+++ b/libctru/source/services/act.c
@@ -1218,7 +1218,7 @@ Result ACTA_SetIsMiiUpdated(u8 accountSlot, bool isDirty)
 	return (Result)cmdbuf[1];
 }
 
-Result ACTA_ReserveTransfer(u8 accountSlot, DeviceInfo *newDevice, char *operator, u32 operatorSize, Handle completionEvent)
+Result ACTA_ReserveTransfer(u8 accountSlot, DeviceInfo *newDevice, char *operatorData, u32 operatorSize, Handle completionEvent)
 {
 	Result ret = 0;
 	u32 *cmdbuf = getThreadCommandBuffer();
@@ -1230,7 +1230,7 @@ Result ACTA_ReserveTransfer(u8 accountSlot, DeviceInfo *newDevice, char *operato
 	cmdbuf[8] = IPC_Desc_SharedHandles(1);
 	cmdbuf[9] = completionEvent;
 	cmdbuf[10] = IPC_Desc_Buffer(operatorSize, IPC_BUFFER_R);
-	cmdbuf[11] = (u32)operator;
+	cmdbuf[11] = (u32)operatorData;
 
 	if (R_FAILED(ret = svcSendSyncRequest(actHandle))) return ret;
 


### PR DESCRIPTION
A function parameter in `ACTA_ReserveTransfer` was named `operator`, which causes issues when compiling with g++ as that is a reserved keyword. I have updated the parameter name to fix this.