### PR TITLE
ns: Add appmemtype parameter to NS_RebootToTitle

### DIFF
--- a/libctru/include/3ds/services/ns.h
+++ b/libctru/include/3ds/services/ns.h
@@ -37,8 +37,9 @@ Result NS_LaunchApplicationFIRM(u64 titleid, u32 flags);
  * @brief Reboots to a title.
  * @param mediatype Mediatype of the title.
  * @param titleid ID of the title to launch.
+ * @param appmemtype The memory type a title should be launched under.
  */
-Result NS_RebootToTitle(u8 mediatype, u64 titleid);
+Result NS_RebootToTitle(u8 mediatype, u64 titleid, u8 appmemtype);
 
 /**
  * @brief Terminates the process with the specified titleid.

--- a/libctru/source/services/ns.c
+++ b/libctru/source/services/ns.c
@@ -83,7 +83,7 @@ Result NS_LaunchApplicationFIRM(u64 titleid, u32 flags)
 	return (Result)cmdbuf[1];
 }
 
-Result NS_RebootToTitle(u8 mediatype, u64 titleid)
+Result NS_RebootToTitle(u8 mediatype, u64 titleid, u8 appmemtype)
 {
 	Result ret = 0;
 	u32 *cmdbuf = getThreadCommandBuffer();
@@ -94,7 +94,7 @@ Result NS_RebootToTitle(u8 mediatype, u64 titleid)
 	cmdbuf[3] = (titleid >> 32) & 0xffffffff;
 	cmdbuf[4] = mediatype;
 	cmdbuf[5] = 0x0; // reserved
-	cmdbuf[6] = 0x0;
+	cmdbuf[6] = appmemtype;
 
 	if(R_FAILED(ret = svcSendSyncRequest(nsHandle)))return ret;
 


### PR DESCRIPTION
This change is mainly to correctly pass the appmemtype parameter to cmdbuf[6].
The NS module writes the content of cmdbuf[6] to offset 0x400 of the Firm Launch parameters so that the device can write it to 0x1FF80030 during boot.
However, when the NS module performs the auto-boot mechanism, it reads the target program’s exheader, compares the program’s memtype with the value at 0x1FF80030, and if they don’t match, the NS module will reboot again using the program’s memtype.
As a result, if you use the NS_RebootToTitle function to launch a mode3 program, the NS module will perform an extra reboot.
Therefore, it is necessary to pass the correct appmemtype to the NS_RebootToTitle function instead of using 0x0.