### PR TITLE
gdbhio: fix _gdbHioExportFileMode, closes #604

### DIFF
--- a/libctru/source/gdbhio.c
+++ b/libctru/source/gdbhio.c
@@ -189,7 +189,7 @@ static int _gdbHioExportFileMode(mode_t mode)
 	if (mode & S_IWOTH) gdbMode |= GDBHIO_S_IWOTH;
 	if (mode & S_IXOTH) gdbMode |= GDBHIO_S_IXOTH;
 
-	return mode;
+	return gdbMode;
 }
 
 


### PR DESCRIPTION
Fixes the following libctru compile error by returning the already computed local variable `gdbMode` instead of the unchanged function parameter `mode`:
```
/home/silentium/projects/libctru/libctru/source/gdbhio.c: In function '_gdbHioExportFileMode':
/home/silentium/projects/libctru/libctru/source/gdbhio.c:176:23: error: variable 'gdbMode' set but not used [-Werror=unused-but-set-variable=]
  176 |         gdbhio_mode_t gdbMode = 0;
      |                       ^~~~~~~
cc1: all warnings being treated as errors
make[1]: *** [/opt/devkitpro/devkitARM/base_rules:40: gdbhio.o] Error 1
make: *** [Makefile:116: lib/libctru.a] Error 2
```